### PR TITLE
Update rive-android

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,11 +1,14 @@
 <Project>
-	<ItemGroup>
-		<PackageVersion Include="Com.Getkeepsafe.Relinker" Version="1.3.1" />
-		<PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.20" />
-		<PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.20" />
-		<PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
-		<PackageVersion Include="Xamarin.Android.Volley" Version="1.2.1.9" />
-		<PackageVersion Include="Xamarin.AndroidX.Lifecycle.Extensions" Version="2.2.0.19" />
-		<PackageVersion Include="Xamarin.Kotlin.StdLib" Version="1.9.23" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="Com.Getkeepsafe.Relinker" Version="1.3.1" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.20" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.20" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    <PackageVersion Include="Xamarin.Android.Volley" Version="1.2.1.9" />
+    <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.7" />
+    <PackageVersion Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.0.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Core.Core.Ktx" Version="1.12.0.4" />
+    <PackageVersion Include="Xamarin.AndroidX.Startup.StartupRuntime" Version="1.1.1.11" />
+    <PackageVersion Include="Xamarin.Kotlin.StdLib" Version="1.9.23" />
+  </ItemGroup>
 </Project>

--- a/samples/Example/Pages/StateMachinePage.xaml
+++ b/samples/Example/Pages/StateMachinePage.xaml
@@ -1,63 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
-<ContentPage
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:riveMaui="clr-namespace:Rive.Maui;assembly=Rive.Maui"
-    x:Class="Example.Pages.StateMachinePage"
-    Title="StateMachine">
-    <Grid RowDefinitions="350,*" RowSpacing="25">
-        <riveMaui:RivePlayer
-            Grid.Row="0"
-            Fit="Cover"
-            ResourceName="animatedloginscreen">
-            <riveMaui:BoolInput
-                StateMachineName="Login Machine"
-                InputName="isChecking"
-                Value="{Binding IsToggled, Source={x:Reference IsCheckingSwitch}}" />
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:riveMaui="clr-namespace:Rive.Maui;assembly=Rive.Maui"
+             x:Class="Example.Pages.StateMachinePage"
+             Title="StateMachine">
+    <ScrollView>
+        <Grid RowDefinitions="350,*"
+              RowSpacing="25">
+            <riveMaui:RivePlayer Grid.Row="0"
+                                 Fit="Cover"
+                                 ResourceName="animatedloginscreen">
+                <riveMaui:BoolInput StateMachineName="Login Machine"
+                                    InputName="isChecking"
+                                    Value="{Binding IsToggled, Source={x:Reference IsCheckingSwitch}}" />
 
-            <riveMaui:NumberInput
-                StateMachineName="Login Machine"
-                InputName="numLook"
-                Value="{Binding Value, Source={x:Reference LookSlider}}" />
+                <riveMaui:NumberInput StateMachineName="Login Machine"
+                                      InputName="numLook"
+                                      Value="{Binding Value, Source={x:Reference LookSlider}}" />
 
-            <riveMaui:BoolInput
-                StateMachineName="Login Machine"
-                InputName="isHandsUp"
-                Value="{Binding IsToggled, Source={x:Reference IsHandsUpSwitch}}" />
+                <riveMaui:BoolInput StateMachineName="Login Machine"
+                                    InputName="isHandsUp"
+                                    Value="{Binding IsToggled, Source={x:Reference IsHandsUpSwitch}}" />
 
-            <riveMaui:TriggerInput
-                x:Name="TrigFail"
-                StateMachineName="Login Machine"
-                InputName="trigFail" />
+                <riveMaui:TriggerInput x:Name="TrigFail"
+                                       StateMachineName="Login Machine"
+                                       InputName="trigFail" />
 
-            <riveMaui:TriggerInput
-                x:Name="TrigSuccess"
-                StateMachineName="Login Machine"
-                InputName="trigSuccess" />
-        </riveMaui:RivePlayer>
+                <riveMaui:TriggerInput x:Name="TrigSuccess"
+                                       StateMachineName="Login Machine"
+                                       InputName="trigSuccess" />
+            </riveMaui:RivePlayer>
 
-        <StackLayout Grid.Row="1" Spacing="25" Padding="25, 0">
-            <HorizontalStackLayout Spacing="10">
-                <Switch x:Name="IsCheckingSwitch" />
-                <Label Text="Checking" VerticalOptions="Center" />
-            </HorizontalStackLayout>
+            <StackLayout Grid.Row="1"
+                         Spacing="25"
+                         Padding="25, 0">
+                <HorizontalStackLayout Spacing="10">
+                    <Switch x:Name="IsCheckingSwitch" />
+                    <Label Text="Checking"
+                           VerticalOptions="Center" />
+                </HorizontalStackLayout>
 
-            <Slider
-                x:Name="LookSlider"
-                IsEnabled="{Binding IsToggled, Source={x:Reference IsCheckingSwitch}}"
-                Minimum="0"
-                Maximum="100"
-                Value="0" />
+                <Slider x:Name="LookSlider"
+                        IsEnabled="{Binding IsToggled, Source={x:Reference IsCheckingSwitch}}"
+                        Minimum="0"
+                        Maximum="100"
+                        Value="0" />
 
-            <HorizontalStackLayout Spacing="10">
-                <Switch x:Name="IsHandsUpSwitch" />
-                <Label Text="Hands up" VerticalOptions="Center" />
-            </HorizontalStackLayout>
+                <HorizontalStackLayout Spacing="10">
+                    <Switch x:Name="IsHandsUpSwitch" />
+                    <Label Text="Hands up"
+                           VerticalOptions="Center" />
+                </HorizontalStackLayout>
 
-            <Button Text="Failure" Command="{Binding FireCommand, Source={x:Reference TrigFail}}" />
+                <Button Text="Failure"
+                        Command="{Binding FireCommand, Source={x:Reference TrigFail}}" />
 
-            <Button Text="Success" Command="{Binding FireCommand, Source={x:Reference TrigSuccess}}" />
-        </StackLayout>
-    </Grid>
+                <Button Text="Success"
+                        Command="{Binding FireCommand, Source={x:Reference TrigSuccess}}" />
+            </StackLayout>
+        </Grid>
+    </ScrollView>
 </ContentPage>

--- a/samples/Example/Pages/TouchInputPage.xaml
+++ b/samples/Example/Pages/TouchInputPage.xaml
@@ -1,38 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
-<ContentPage
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:riveMaui="clr-namespace:Rive.Maui;assembly=Rive.Maui"
-    xmlns:pages="clr-namespace:Example.Pages"
-    x:Class="Example.Pages.TouchInputPage"
-    x:DataType="pages:TouchInputPageViewModel"
-    Title="TouchPage">
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:riveMaui="clr-namespace:Rive.Maui;assembly=Rive.Maui"
+             xmlns:pages="clr-namespace:Example.Pages"
+             x:Class="Example.Pages.TouchInputPage"
+             x:DataType="pages:TouchInputPageViewModel"
+             Title="TouchPage">
 
     <ContentPage.BindingContext>
         <pages:TouchInputPageViewModel />
     </ContentPage.BindingContext>
 
-    <VerticalStackLayout>
-        <Label
-            Margin="0,50,0,0"
-            Text="{Binding CurrentStateName, StringFormat='State name: {0}'}"
-            HorizontalOptions="Center"
-            FontAttributes="Bold"
-            FontSize="20" />
+    <ScrollView>
+        <VerticalStackLayout>
+            <Label Margin="0,50,0,0"
+                   Text="{Binding CurrentStateName, StringFormat='State name: {0}'}"
+                   HorizontalOptions="Center"
+                   FontAttributes="Bold"
+                   FontSize="20" />
 
-        <Label
-            Text="{Binding NumberInputValue, StringFormat='Number input: {0}'}"
-            HorizontalOptions="Center"
-            FontAttributes="Bold"
-            FontSize="20" />
+            <Label Text="{Binding NumberInputValue, StringFormat='Number input: {0}'}"
+                   HorizontalOptions="Center"
+                   FontAttributes="Bold"
+                   FontSize="20" />
 
-        <riveMaui:RivePlayer
-            Margin="0,40,0,0"
-            ResourceName="lil_guy"
-            Fit="Cover"
-            HeightRequest="500"
-            OnStateMachineChangeCommand="{Binding StateChangedCommand}" />
-    </VerticalStackLayout>
-
+            <riveMaui:RivePlayer Margin="0,40,0,0"
+                                 ResourceName="lil_guy"
+                                 Fit="Cover"
+                                 HeightRequest="500"
+                                 OnStateMachineChangeCommand="{Binding StateChangedCommand}" />
+        </VerticalStackLayout>
+    </ScrollView>
 </ContentPage>

--- a/src/Rive.Android/README.MD
+++ b/src/Rive.Android/README.MD
@@ -1,4 +1,4 @@
 # Rive.Android
 
 Current version
-[9.3.0](https://github.com/rive-app/rive-android)
+[9.3.2](https://github.com/rive-app/rive-android/blob/master/CHANGELOG.md)

--- a/src/Rive.Android/Rive.Android.csproj
+++ b/src/Rive.Android/Rive.Android.csproj
@@ -19,7 +19,13 @@
 	<ItemGroup>
 		<PackageReference Include="Com.Getkeepsafe.Relinker" />
 		<PackageReference Include="Xamarin.Android.Volley" />
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Extensions" />
+		<PackageReference Include="Xamarin.AndroidX.AppCompat" />
+		
+		<!-- Xamarin.AndroidX.Collection.Ktx helped fix the issue from https://stackoverflow.com/a/77949214/1114918 -->
+		<PackageReference Include="Xamarin.AndroidX.Collection.Ktx" />
+		
+		<PackageReference Include="Xamarin.AndroidX.Core.Core.Ktx" />
+		<PackageReference Include="Xamarin.AndroidX.Startup.StartupRuntime" />
 		<PackageReference Include="Xamarin.Kotlin.StdLib" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
- Update rive-android to 9.3.2
- Follow dependencies from https://central.sonatype.com/artifact/app.rive/rive-android/dependencies
- Use `Xamarin.AndroidX.Collection.Ktx` to fix [`Type androidx.collection.ArraySetKt is defined multiple times`](https://stackoverflow.com/questions/77949068/error-java0000-type-androidx-collection-arraysetkt-is-defined-multiple-times)
- Remove seemingly unused `Xamarin.AndroidX.Lifecycle.Extensions`
- Add scrollview to allow for smaller devices