### PR TITLE
Downgrade Maui nugets

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,8 +2,8 @@
   <ItemGroup>
     <PackageVersion Include="Com.Getkeepsafe.Relinker" Version="1.3.1" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.20" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.20" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.7" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageVersion Include="Xamarin.Android.Volley" Version="1.2.1.9" />
     <PackageVersion Include="Xamarin.AndroidX.Lifecycle.Extensions" Version="2.2.0.19" />

--- a/samples/Example/Pages/TouchInputPageViewModel.cs
+++ b/samples/Example/Pages/TouchInputPageViewModel.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Rive.Maui;

--- a/samples/Example/Properties/launchSettings.json
+++ b/samples/Example/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "Windows Machine": {
-      "commandName": "MsixPackage",
-      "nativeDebugging": false
-    }
-  }
-}


### PR DESCRIPTION
Consumers of the package might not be on the latest version for several reasons (regressions, new bugs, etc.). 
Only ViewRenderer is used so the latest bug fixes don't really matter.

Downgraded to latest included in workload (8.0.7)

https://www.nuget.org/packages/Rive.Maui/#dependencies-body-tab